### PR TITLE
Revert output format

### DIFF
--- a/apps/cargo-scout-audit/src/startup.rs
+++ b/apps/cargo-scout-audit/src/startup.rs
@@ -93,8 +93,14 @@ pub struct Scout {
     #[clap(last = true, help = "Arguments for `cargo check`.")]
     pub args: Vec<String>,
 
-    #[clap(short, long, value_name = "type", help = "Sets the output type")]
-    pub output_formats: Vec<OutputFormat>,
+    #[clap(
+        short,
+        long,
+        value_name = "type",
+        help = "Sets the output type",
+        value_delimiter = ','
+    )]
+    pub output_format: Vec<OutputFormat>,
 
     #[clap(long, value_name = "path", help = "Path to the output file.")]
     pub output_path: Option<PathBuf>,
@@ -480,7 +486,7 @@ fn do_report(
             project_info,
             &detectors_info,
             opts.output_path,
-            &opts.output_formats,
+            &opts.output_format,
         )?;
     }
 

--- a/apps/cargo-scout-audit/tests/main.rs
+++ b/apps/cargo-scout-audit/tests/main.rs
@@ -129,7 +129,7 @@ mod tests {
         // Given
         let scout_opts = Scout {
             manifest_path: Some(CONTRACT_PATH.clone()),
-            output_formats: vec![format.clone()],
+            output_format: vec![format.clone()],
             output_path: Some(PathBuf::from(output_file)),
             ..Scout::default()
         };


### PR DESCRIPTION
This PR intends to revert the output format flag from `--output-formats` to `--output-format`, while keeping short version `-o`.
Additionally, two forms of usage are expected:
 - `... -o=value1,value2`
 - `... -o=value1 -o=value2`