### PR TITLE
Added test_finding_presence.

### DIFF
--- a/apps/cargo-scout-audit/src/startup.rs
+++ b/apps/cargo-scout-audit/src/startup.rs
@@ -280,7 +280,7 @@ fn capture_noop<T, E, F: FnOnce() -> Result<T, E>>(cb: F) -> Result<(Vec<String>
 }
 
 #[tracing::instrument(name = "RUN SCOUT", skip_all)]
-pub fn run_scout(mut opts: Scout) -> Result<()> {
+pub fn run_scout(mut opts: Scout) -> Result<Vec<Value>> {
     opts.validate()?;
     opts.prepare_args();
 
@@ -290,14 +290,14 @@ pub fn run_scout(mut opts: Scout) -> Result<()> {
 
     if opts.toolchain {
         println!("{}", toolchain);
-        return Ok(());
+        return Ok(vec![]);
     }
 
     if let Some(mut child) = run_scout_in_nightly(toolchain)? {
         child
             .wait()
             .with_context(|| "Failed to wait for nightly child process")?;
-        return Ok(());
+        return Ok(vec![]);
     }
 
     if let Err(e) = VersionChecker::new().check_for_updates() {
@@ -368,7 +368,7 @@ pub fn run_scout(mut opts: Scout) -> Result<()> {
 
     if opts.list_detectors {
         list_detectors(&profile_detectors);
-        return Ok(());
+        return Ok(vec![]);
     }
 
     let filtered_detectors = if let Some(filter) = &opts.filter {
@@ -393,7 +393,7 @@ pub fn run_scout(mut opts: Scout) -> Result<()> {
     if opts.detectors_metadata {
         let json = to_string_pretty(&detectors_info);
         println!("{}", json.unwrap());
-        return Ok(());
+        return Ok(vec![]);
     }
 
     let project_info = ProjectInfo::get_project_info(&metadata)
@@ -424,7 +424,7 @@ pub fn run_scout(mut opts: Scout) -> Result<()> {
             .text_str("Nothing was analyzed. Check your build system for errors.")
             .print();
         println!("{}", string);
-        return Ok(());
+        return Ok(vec![]);
     }
 
     let (successful_findings, _failed_findings) = split_findings(findings, &crates);
@@ -462,18 +462,20 @@ pub fn run_scout(mut opts: Scout) -> Result<()> {
     };
     // Generate report
     do_report(
-        console_findings,
+        &console_findings,
         crates,
         project_info,
         detectors_info,
         output_string_vscode,
         opts,
         inside_vscode,
-    )
+    )?;
+
+    Ok(console_findings)
 }
 
 fn do_report(
-    findings: Vec<Value>,
+    findings: &Vec<Value>,
     crates: HashMap<String, bool>,
     project_info: ProjectInfo,
     detectors_info: HashMap<String, LintInfo>,
@@ -487,9 +489,9 @@ fn do_report(
             .write_all(output_string.as_bytes())
             .with_context(|| ("Failed to write stdout content"))?;
     } else {
-        crate::output::console::render_report(&findings, &crates, &detectors_info)?;
+        crate::output::console::render_report(findings, &crates, &detectors_info)?;
         generate_report(
-            &findings,
+            findings,
             &crates,
             project_info,
             &detectors_info,


### PR DESCRIPTION
The test checks that some change to Scout or the detectors hasn't broken the basic communication between modules. It expects to find among the findings exactly:
* 1 overflow_check
* 1 soroban_version
* 1 integer_overflow_underflow
* 1 divide_before_multiply

and nothing else. Anything else is considered a fail.