### PR TITLE
init-instead-of-constructor detector

### DIFF
--- a/.github/workflows/test-detectors-pr.yml
+++ b/.github/workflows/test-detectors-pr.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install cargo-scout-audit
         working-directory: apps/cargo-scout-audit/crates/cargo-scout-audit
-        run: cargo install --path .
+        run: cargo install --path . --locked
 
       - name: Determine build status and write to file
         run: echo "${{ job.status }}" > status-${{ matrix.os }}.txt

--- a/.github/workflows/test-scout.yml
+++ b/.github/workflows/test-scout.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install local scout
         working-directory: apps/cargo-scout-audit/crates/cargo-scout-audit
-        run: cargo install --path .
+        run: cargo install --path . --locked
 
       - name: Install clippy-sarif and cargo-nextest
         run: cargo install clippy-sarif cargo-nextest --locked

--- a/apps/cargo-scout-audit/Cargo.lock
+++ b/apps/cargo-scout-audit/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-scout-audit"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3623,7 +3623,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout-driver"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/docs/package.json
+++ b/docs/package.json
@@ -40,5 +40,16 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "resolutions": {
+    "webpack": "5.97.1"
+  },
+  "overrides": {
+    "webpack": "5.97.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "webpack": "5.97.1"
+    }
   }
 }

--- a/nightly/2025-08-07/detectors/soroban/Cargo.lock
+++ b/nightly/2025-08-07/detectors/soroban/Cargo.lock
@@ -474,6 +474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "init-instead-of-constructor"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "common",
+ "dylint_internal",
+ "dylint_linting",
+ "if_chain",
+]
+
+[[package]]
 name = "insufficiently-random-values"
 version = "0.1.0"
 dependencies = [

--- a/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/Cargo.toml
+++ b/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition = "2021"
+name = "init-instead-of-constructor"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+common = { workspace = true }
+dylint_internal = { workspace = true }
+dylint_linting = { workspace = true }
+if_chain = { workspace = true }
+clippy_utils = { workspace = true }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
@@ -2,8 +2,12 @@
 
 extern crate rustc_hir;
 extern crate rustc_span;
+extern crate rustc_errors;
 
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::diagnostics::{
+    span_lint,
+    span_lint_and_sugg,
+};
 use common::{
     declarations::{Severity, VulnerabilityClass},
     macros::expose_lint_info,
@@ -11,6 +15,7 @@ use common::{
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Span;
 use std::vec;
+use rustc_errors::Applicability;
 
 const LINT_MESSAGE: &str = "Use the constructor pattern to initialize the contract";
 
@@ -61,11 +66,26 @@ impl<'tcx> LateLintPass<'tcx> for InitInsteadOfConstructor {
             return;
         }
 
+        let Some(name_span) = cx.tcx.def_ident_span(def_id) else {
+            span_lint(cx, INIT_INSTEAD_OF_CONSTRUCTOR, span, LINT_MESSAGE);
+            return;
+        };
+
+        span_lint_and_sugg(
+            cx,
+            INIT_INSTEAD_OF_CONSTRUCTOR,
+            name_span,
+            LINT_MESSAGE,
+            "rename this function to",
+            "__constructor".into(),
+            Applicability::MaybeIncorrect,
+        );
+
         //TODO: This can be improved by getting the span of the function name
         //      and suggesting replacing with __constructor. Unfortunately this
         //      cannot be done at this time because FnKind doesn't expose that
         //      span. We can look into this again after updating the nightly
         //      version.
-        span_lint(cx, INIT_INSTEAD_OF_CONSTRUCTOR, span, LINT_MESSAGE);
+        //span_lint(cx, INIT_INSTEAD_OF_CONSTRUCTOR, span, LINT_MESSAGE);
     }
 }

--- a/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
@@ -1,0 +1,71 @@
+#![feature(rustc_private)]
+
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use clippy_utils::diagnostics::span_lint;
+use common::{
+    declarations::{Severity, VulnerabilityClass},
+    macros::expose_lint_info,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_span::Span;
+use std::vec;
+
+const LINT_MESSAGE: &str = "Use the constructor pattern to initialize the contract";
+
+#[expose_lint_info]
+pub static TOKEN_INTERFACE_EVENTS_INFO: LintInfo = LintInfo {
+    name: env!("CARGO_PKG_NAME"),
+    short_message: LINT_MESSAGE,
+    long_message: "Initialization functions may be sniped by attackers before the deployer has a chance to call them, whereas constructors are guaranteed to be called at constract deployment",
+    severity: Severity::Medium,
+    help: "https://coinfabrik.github.io/scout-audit/docs/detectors/soroban/init-instead-of-constructor",
+    vulnerability_class: VulnerabilityClass::BestPractices,
+};
+
+dylint_linting::impl_late_lint! {
+    pub INIT_INSTEAD_OF_CONSTRUCTOR,
+    Warn,
+    LINT_MESSAGE,
+    InitInsteadOfConstructor::default()
+}
+
+static INITIALIZATION_FUNCTION: [&str; 2] = ["init", "initialize"];
+
+#[derive(Default)]
+struct InitInsteadOfConstructor {}
+
+fn is_relevant_function(name: &str) -> bool {
+    for s in INITIALIZATION_FUNCTION {
+        if name.ends_with(&format!("::{s}")) && !name.ends_with(&format!("Client::<'a>::{s}")) {
+            return true;
+        }
+    }
+    false
+}
+
+impl<'tcx> LateLintPass<'tcx> for InitInsteadOfConstructor {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: rustc_hir::intravisit::FnKind<'tcx>,
+        _: &'tcx rustc_hir::FnDecl<'tcx>,
+        _: &'tcx rustc_hir::Body<'tcx>,
+        span: Span,
+        local_def_id: rustc_span::def_id::LocalDefId,
+    ) {
+        let def_id = local_def_id.to_def_id();
+        let fn_name = cx.tcx.def_path_str(def_id);
+        if !is_relevant_function(&fn_name) {
+            return;
+        }
+
+        //TODO: This can be improved by getting the span of the function name
+        //      and suggesting replacing with __constructor. Unfortunately this
+        //      cannot be done at this time because FnKind doesn't expose that
+        //      span. We can look into this again after updating the nightly
+        //      version.
+        span_lint(cx, INIT_INSTEAD_OF_CONSTRUCTOR, span, LINT_MESSAGE);
+    }
+}

--- a/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
@@ -77,12 +77,5 @@ impl<'tcx> LateLintPass<'tcx> for InitInsteadOfConstructor {
             "__constructor".into(),
             Applicability::MaybeIncorrect,
         );
-
-        //TODO: This can be improved by getting the span of the function name
-        //      and suggesting replacing with __constructor. Unfortunately this
-        //      cannot be done at this time because FnKind doesn't expose that
-        //      span. We can look into this again after updating the nightly
-        //      version.
-        //span_lint(cx, INIT_INSTEAD_OF_CONSTRUCTOR, span, LINT_MESSAGE);
     }
 }

--- a/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/init-instead-of-constructor/src/lib.rs
@@ -1,21 +1,18 @@
 #![feature(rustc_private)]
 
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_span;
-extern crate rustc_errors;
 
-use clippy_utils::diagnostics::{
-    span_lint,
-    span_lint_and_sugg,
-};
+use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
 use common::{
     declarations::{Severity, VulnerabilityClass},
     macros::expose_lint_info,
 };
+use rustc_errors::Applicability;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Span;
 use std::vec;
-use rustc_errors::Applicability;
 
 const LINT_MESSAGE: &str = "Use the constructor pattern to initialize the contract";
 

--- a/test-cases/soroban/Cargo.lock
+++ b/test-cases/soroban/Cargo.lock
@@ -883,6 +883,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "init-instead-of-constructor-remediated-1"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "init-instead-of-constructor-vulnerable-1"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "insufficiently-random-values-remediated-1"
 version = "0.1.0"
 dependencies = [

--- a/test-cases/soroban/init-instead-of-constructor/remediated/remediated-1/Cargo.toml
+++ b/test-cases/soroban/init-instead-of-constructor/remediated/remediated-1/Cargo.toml
@@ -1,0 +1,17 @@
+
+[package]
+edition = "2021"
+name = "init-instead-of-constructor-remediated-1"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/init-instead-of-constructor/remediated/remediated-1/src/lib.rs
+++ b/test-cases/soroban/init-instead-of-constructor/remediated/remediated-1/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+#[derive(Debug, Clone)]
+#[contracttype]
+pub struct CacheEntry {
+    admin: Address,
+}
+
+const STATE: Symbol = symbol_short!("STATE");
+
+#[contract]
+pub struct InitInsteadOfConstructor;
+
+#[contractimpl]
+impl InitInsteadOfConstructor {
+    pub fn __constructor(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&STATE, &admin);
+    }
+}

--- a/test-cases/soroban/init-instead-of-constructor/vulnerable/vulnerable-1/Cargo.toml
+++ b/test-cases/soroban/init-instead-of-constructor/vulnerable/vulnerable-1/Cargo.toml
@@ -1,0 +1,17 @@
+
+[package]
+edition = "2021"
+name = "init-instead-of-constructor-vulnerable-1"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/init-instead-of-constructor/vulnerable/vulnerable-1/src/lib.rs
+++ b/test-cases/soroban/init-instead-of-constructor/vulnerable/vulnerable-1/src/lib.rs
@@ -1,0 +1,22 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+#[derive(Debug, Clone)]
+#[contracttype]
+pub struct CacheEntry {
+    admin: Address,
+}
+
+const STATE: Symbol = symbol_short!("STATE");
+
+#[contract]
+pub struct InitInsteadOfConstructor;
+
+#[contractimpl]
+impl InitInsteadOfConstructor {
+    pub fn init(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&STATE, &admin);
+    }
+}


### PR DESCRIPTION
## Init Instead of Constructor detector

### Description
Category: Best Practices
Severity:  Medium

Since version 22.0.0 of the Soroban CLI, constructors are supported to automatically initialize contracts the moment they're deployed. Use constructors instead of initializers.

### Why is this bad?
Initializers are error-prone and subject to unauthorized initializations, where someone other than the person who deployed the contract calls the initializer, taking control of the deployment and requiring a second deployment. A more serious issue is that initializer logic is easy to get wrong, especially with regards to preventing double initialization. Constructors solve both of these issues automatically by handing the responsibility over to the blockchain.

### PR contents
This PR has new detector code, tests and documentation.