### PR TITLE
Add `infinite-recursion` detector and test-cases

### DIFF
--- a/apps/cargo-scout-audit/Cargo.lock
+++ b/apps/cargo-scout-audit/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-scout-audit"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3623,7 +3623,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout-driver"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/docs/docs/detectors/soroban/32-infinite-recursion-over-storage.md
+++ b/docs/docs/detectors/soroban/32-infinite-recursion-over-storage.md
@@ -7,13 +7,13 @@
 - Detector: [`infinite-recursion-over-storage`](https://github.com/CoinFabrik/scout-soroban/tree/main/detectors/infinite-recursion-over-storage)
 - Test Cases: [`infinite-recursion-over-storage-1`](https://github.com/CoinFabrik/scout-soroban/tree/main/test-cases/infinite-recursion-over-storage/infinite-recursion-over-storage-1)
 
-This detector looks for recursive call cycles reachable from a Soroban entrypoint. In Soroban, recursive execution already risks exhausting gas or overflowing the call stack, even when the recursive flow does not touch storage.
+This detector looks for recursive call cycles reachable from a Soroban entrypoint. In Soroban, recursive execution can exhaust gas or overflow the call stack when the recursion has no effective terminal condition.
 
 ## Why is this bad?
 
 Recursive cycles without an exit condition can keep calling themselves until execution runs out of gas or stack budget. That creates a denial-of-service pattern and can make otherwise simple entrypoints unexpectedly revert.
 
-This detector is intentionally conservative in one dimension: it only considers recursion reachable from Soroban entrypoints. But once a reachable recursive cycle exists, it warns regardless of whether storage is touched along the way.
+The detector is intentionally scoped to recursion reachable from Soroban entrypoints. It reports direct self-recursion and mutual-recursion cycles that can keep execution from terminating.
 
 ## Issue example
 
@@ -35,7 +35,7 @@ fn write_once(env: Env, depth: u32) -> u32 {
 }
 ```
 
-By removing the recursive cycle, the function returns normally. More generally, the fix is to break the recursive cycle so the entrypoint cannot keep consuming gas indefinitely.
+By removing the recursive cycle, the function returns normally. A bounded recursion with a clear terminal condition or upper bound also addresses the runtime issue. This detector is structural and does not prove termination, so removing the recursive cycle or rewriting the flow iteratively is the most reliable way to avoid the lint.
 
 The remediated examples can be found [here](https://github.com/CoinFabrik/scout-soroban/tree/main/test-cases/infinite-recursion-over-storage/infinite-recursion-over-storage-1/remediated-example).
 

--- a/docs/docs/detectors/soroban/32-infinite-recursion-over-storage.md
+++ b/docs/docs/detectors/soroban/32-infinite-recursion-over-storage.md
@@ -1,0 +1,44 @@
+# Infinite recursion
+
+## Description
+
+- Category: `Denial of service`
+- Severity: `Medium`
+- Detector: [`infinite-recursion-over-storage`](https://github.com/CoinFabrik/scout-soroban/tree/main/detectors/infinite-recursion-over-storage)
+- Test Cases: [`infinite-recursion-over-storage-1`](https://github.com/CoinFabrik/scout-soroban/tree/main/test-cases/infinite-recursion-over-storage/infinite-recursion-over-storage-1)
+
+This detector looks for recursive call cycles reachable from a Soroban entrypoint. In Soroban, recursive execution already risks exhausting gas or overflowing the call stack, even when the recursive flow does not touch storage.
+
+## Why is this bad?
+
+Recursive cycles without an exit condition can keep calling themselves until execution runs out of gas or stack budget. That creates a denial-of-service pattern and can make otherwise simple entrypoints unexpectedly revert.
+
+This detector is intentionally conservative in one dimension: it only considers recursion reachable from Soroban entrypoints. But once a reachable recursive cycle exists, it warns regardless of whether storage is touched along the way.
+
+## Issue example
+
+```rust
+pub fn recurse(env: Env, depth: u32) -> u32 {
+    Self::recurse(env, depth + 1)
+}
+```
+
+The function immediately calls itself again with no terminating condition. The flow can continue until the call stack or gas budget is exhausted.
+
+The vulnerable examples can be found [here](https://github.com/CoinFabrik/scout-soroban/tree/main/test-cases/infinite-recursion-over-storage/infinite-recursion-over-storage-1/vulnerable-example).
+
+## Remediated example
+
+```rust
+fn write_once(env: Env, depth: u32) -> u32 {
+    depth
+}
+```
+
+By removing the recursive cycle, the function returns normally. More generally, the fix is to break the recursive cycle so the entrypoint cannot keep consuming gas indefinitely.
+
+The remediated examples can be found [here](https://github.com/CoinFabrik/scout-soroban/tree/main/test-cases/infinite-recursion-over-storage/infinite-recursion-over-storage-1/remediated-example).
+
+## How is it detected?
+
+The detector builds a local call graph for the contract, starts from Soroban entrypoints, and computes recursive strongly connected components over the reachable functions. A warning is emitted on recursive callsites inside a reachable recursive cycle, including direct self-recursion and longer mutual-recursion chains.

--- a/nightly/2025-08-07/common/analysis/src/function_call_visitor/mod.rs
+++ b/nightly/2025-08-07/common/analysis/src/function_call_visitor/mod.rs
@@ -4,7 +4,6 @@ extern crate rustc_span;
 
 use std::collections::{HashMap, HashSet};
 
-use if_chain::if_chain;
 use rustc_hir::{
     intravisit::{walk_expr, Visitor},
     Expr, ExprKind,
@@ -57,21 +56,25 @@ impl<'a, 'tcx> Visitor<'tcx> for FunctionCallVisitor<'a, 'tcx> {
     /// # Parameters
     /// - `expr`: The expression being visited.
     fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
-        // If the expression is a function call, record it in the call graph.
-        if_chain! {
-            if let ExprKind::Call(call_expr, _) = expr.kind; // Check if the expression is a call.
-            if let ExprKind::Path(ref qpath) = call_expr.kind; // Ensure the call is a path expression.
-            if let Some(def_id) = self.cx.qpath_res(qpath, call_expr.hir_id).opt_def_id(); // Resolve the path to a DefId.
-            then {
-                // Add the called function's DefId to the current function's entry in the call graph.
-                self.call_graph
-                    .entry(self.current_fn)
-                    .or_default()
-                    .insert(def_id);
-            }
+        if let Some(def_id) = resolve_call_def_id(self.cx, expr) {
+            self.call_graph
+                .entry(self.current_fn)
+                .or_default()
+                .insert(def_id);
         }
 
         // Continue walking through the expression tree.
         walk_expr(self, expr);
+    }
+}
+
+fn resolve_call_def_id(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
+    match expr.kind {
+        ExprKind::Call(call_expr, _) => match call_expr.kind {
+            ExprKind::Path(ref qpath) => cx.qpath_res(qpath, call_expr.hir_id).opt_def_id(),
+            _ => None,
+        },
+        ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
+        _ => None,
     }
 }

--- a/nightly/2025-08-07/common/analysis/src/function_call_visitor/mod.rs
+++ b/nightly/2025-08-07/common/analysis/src/function_call_visitor/mod.rs
@@ -68,7 +68,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FunctionCallVisitor<'a, 'tcx> {
     }
 }
 
-fn resolve_call_def_id(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
+pub fn resolve_call_def_id(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
     match expr.kind {
         ExprKind::Call(call_expr, _) => match call_expr.kind {
             ExprKind::Path(ref qpath) => cx.qpath_res(qpath, call_expr.hir_id).opt_def_id(),

--- a/nightly/2025-08-07/common/analysis/src/lib.rs
+++ b/nightly/2025-08-07/common/analysis/src/lib.rs
@@ -4,7 +4,7 @@ pub use dylint_linting;
 pub use paste;
 
 mod function_call_visitor;
-pub use function_call_visitor::FunctionCallVisitor;
+pub use function_call_visitor::{resolve_call_def_id, FunctionCallVisitor};
 
 mod soroban_utils;
 pub use soroban_utils::*;

--- a/nightly/2025-08-07/detectors/soroban/Cargo.lock
+++ b/nightly/2025-08-07/detectors/soroban/Cargo.lock
@@ -484,6 +484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "infinite-recursion-over-storage"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "common",
+ "dylint_internal",
+ "dylint_linting",
+]
+
+[[package]]
 name = "init-instead-of-constructor"
 version = "0.1.0"
 dependencies = [

--- a/nightly/2025-08-07/detectors/soroban/Cargo.lock
+++ b/nightly/2025-08-07/detectors/soroban/Cargo.lock
@@ -474,6 +474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "infinite-recursion-over-storage"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "common",
+ "dylint_internal",
+ "dylint_linting",
+]
+
+[[package]]
 name = "insufficiently-random-values"
 version = "0.1.0"
 dependencies = [

--- a/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/Cargo.toml
+++ b/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils = { workspace = true }
+common = { workspace = true }
+dylint_internal = { workspace = true }
+dylint_linting = { workspace = true }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/src/lib.rs
@@ -7,13 +7,13 @@ use std::collections::{HashMap, HashSet};
 
 use clippy_utils::diagnostics::span_lint_and_help;
 use common::{
-    analysis::{is_soroban_function, FunctionCallVisitor},
+    analysis::{is_soroban_function, resolve_call_def_id, FunctionCallVisitor},
     declarations::{Severity, VulnerabilityClass},
     macros::expose_lint_info,
 };
 use rustc_hir::{
     intravisit::{walk_expr, FnKind, Visitor},
-    Body, Expr, ExprKind, FnDecl, QPath,
+    Body, Expr, FnDecl,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::{
@@ -274,27 +274,8 @@ impl<'a, 'tcx> Visitor<'tcx> for CallEdgeVisitor<'a, 'tcx> {
     }
 }
 
-fn resolve_call_def_id(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
-    match expr.kind {
-        ExprKind::Call(callee_expr, _) => match callee_expr.kind {
-            ExprKind::Path(ref qpath) => resolve_qpath_def_id(cx, qpath, callee_expr.hir_id),
-            _ => None,
-        },
-        ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
-        _ => None,
-    }
-}
-
 struct CallEdgeVisitor<'a, 'tcx> {
     cx: &'a LateContext<'tcx>,
     caller: DefId,
     edges: Vec<CallEdge>,
-}
-
-fn resolve_qpath_def_id(
-    cx: &LateContext<'_>,
-    qpath: &QPath<'_>,
-    hir_id: rustc_hir::HirId,
-) -> Option<DefId> {
-    cx.qpath_res(qpath, hir_id).opt_def_id()
 }

--- a/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/src/lib.rs
@@ -1,0 +1,293 @@
+#![feature(rustc_private)]
+
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use std::collections::{HashMap, HashSet};
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use common::{
+    analysis::{is_soroban_function, FunctionCallVisitor},
+    declarations::{Severity, VulnerabilityClass},
+    macros::expose_lint_info,
+};
+use rustc_hir::{
+    intravisit::{walk_expr, FnKind, Visitor},
+    Body, Expr, ExprKind, FnDecl, QPath,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_span::{
+    def_id::{DefId, LocalDefId},
+    Span,
+};
+
+const LINT_MESSAGE: &str =
+    "Recursive call flows can recurse indefinitely and exhaust gas or revert";
+
+#[expose_lint_info]
+pub static INFINITE_RECURSION_OVER_STORAGE_INFO: LintInfo = LintInfo {
+    name: env!("CARGO_PKG_NAME"),
+    short_message: LINT_MESSAGE,
+    long_message: "Recursive call flows can recurse indefinitely and exhaust gas or revert. The detector flags recursive cycles reachable from Soroban entrypoints, including direct self-recursion and mutual recursion.",
+    severity: Severity::Medium,
+    help: "https://coinfabrik.github.io/scout-audit/docs/detectors/soroban/infinite-recursion-over-storage",
+    vulnerability_class: VulnerabilityClass::DoS,
+};
+
+dylint_linting::impl_late_lint! {
+    pub INFINITE_RECURSION_OVER_STORAGE,
+    Warn,
+    LINT_MESSAGE,
+    InfiniteRecursionOverStorage::default()
+}
+
+#[derive(Default)]
+struct InfiniteRecursionOverStorage {
+    checked_functions: HashSet<String>,
+    functions: HashSet<DefId>,
+    function_call_graph: HashMap<DefId, HashSet<DefId>>,
+    call_edges_with_spans: Vec<CallEdge>,
+}
+
+#[derive(Clone, Copy)]
+struct CallEdge {
+    caller: DefId,
+    callee: DefId,
+    span: Span,
+}
+
+impl<'tcx> LateLintPass<'tcx> for InfiniteRecursionOverStorage {
+    fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
+        let reachable = collect_reachable_entrypoints(
+            cx,
+            &self.checked_functions,
+            &self.functions,
+            &self.function_call_graph,
+        );
+
+        if reachable.is_empty() {
+            return;
+        }
+
+        let reachable_graph = build_reachable_graph(&reachable, &self.function_call_graph);
+        let recursive_sccs = compute_recursive_sccs(&reachable, &reachable_graph);
+
+        for component in recursive_sccs {
+            let component_members: HashSet<DefId> = component.into_iter().collect();
+            for edge in &self.call_edges_with_spans {
+                if component_members.contains(&edge.caller)
+                    && component_members.contains(&edge.callee)
+                {
+                    span_lint_and_help(
+                        cx,
+                        INFINITE_RECURSION_OVER_STORAGE,
+                        edge.span,
+                        LINT_MESSAGE,
+                        None,
+                        "Break the recursive cycle so the entrypoint cannot recurse indefinitely.",
+                    );
+                }
+            }
+        }
+    }
+
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        _: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        span: Span,
+        local_def_id: LocalDefId,
+    ) {
+        let def_id = local_def_id.to_def_id();
+        self.checked_functions.insert(cx.tcx.def_path_str(def_id));
+        self.functions.insert(def_id);
+
+        if span.from_expansion() {
+            return;
+        }
+
+        let mut function_call_visitor =
+            FunctionCallVisitor::new(cx, def_id, &mut self.function_call_graph);
+        function_call_visitor.visit_body(body);
+
+        let mut call_edge_visitor = CallEdgeVisitor {
+            cx,
+            caller: def_id,
+            edges: Vec::new(),
+        };
+        call_edge_visitor.visit_body(body);
+        self.call_edges_with_spans.extend(call_edge_visitor.edges);
+    }
+}
+
+fn collect_reachable_entrypoints(
+    cx: &LateContext<'_>,
+    checked_functions: &HashSet<String>,
+    functions: &HashSet<DefId>,
+    graph: &HashMap<DefId, HashSet<DefId>>,
+) -> HashSet<DefId> {
+    let mut reachable = HashSet::new();
+
+    for function in functions {
+        if !is_soroban_function(cx, checked_functions, function) {
+            continue;
+        }
+
+        let mut stack = vec![*function];
+        while let Some(current) = stack.pop() {
+            if !reachable.insert(current) {
+                continue;
+            }
+
+            if let Some(callees) = graph.get(&current) {
+                for callee in callees {
+                    if functions.contains(callee) && !reachable.contains(callee) {
+                        stack.push(*callee);
+                    }
+                }
+            }
+        }
+    }
+
+    reachable
+}
+
+fn build_reachable_graph(
+    reachable: &HashSet<DefId>,
+    graph: &HashMap<DefId, HashSet<DefId>>,
+) -> HashMap<DefId, HashSet<DefId>> {
+    let mut reachable_graph = HashMap::new();
+
+    for function in reachable {
+        let children = graph
+            .get(function)
+            .into_iter()
+            .flat_map(|callees| callees.iter().copied())
+            .filter(|callee| reachable.contains(callee))
+            .collect::<HashSet<_>>();
+        reachable_graph.insert(*function, children);
+    }
+
+    reachable_graph
+}
+
+fn compute_recursive_sccs(
+    reachable: &HashSet<DefId>,
+    graph: &HashMap<DefId, HashSet<DefId>>,
+) -> Vec<Vec<DefId>> {
+    let mut index = 0usize;
+    let mut stack = Vec::new();
+    let mut on_stack = HashSet::new();
+    let mut indexes = HashMap::new();
+    let mut lowlinks = HashMap::new();
+    let mut components = Vec::new();
+
+    for node in reachable {
+        if !indexes.contains_key(node) {
+            strong_connect(
+                *node,
+                graph,
+                &mut index,
+                &mut stack,
+                &mut on_stack,
+                &mut indexes,
+                &mut lowlinks,
+                &mut components,
+            );
+        }
+    }
+
+    components
+        .into_iter()
+        .filter(|component| {
+            if component.len() > 1 {
+                return true;
+            }
+
+            component
+                .first()
+                .and_then(|node| graph.get(node).map(|children| children.contains(node)))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+fn strong_connect(
+    node: DefId,
+    graph: &HashMap<DefId, HashSet<DefId>>,
+    index: &mut usize,
+    stack: &mut Vec<DefId>,
+    on_stack: &mut HashSet<DefId>,
+    indexes: &mut HashMap<DefId, usize>,
+    lowlinks: &mut HashMap<DefId, usize>,
+    components: &mut Vec<Vec<DefId>>,
+) {
+    indexes.insert(node, *index);
+    lowlinks.insert(node, *index);
+    *index += 1;
+    stack.push(node);
+    on_stack.insert(node);
+
+    if let Some(children) = graph.get(&node) {
+        for child in children {
+            if !indexes.contains_key(child) {
+                strong_connect(
+                    *child, graph, index, stack, on_stack, indexes, lowlinks, components,
+                );
+                let child_lowlink = *lowlinks.get(child).unwrap();
+                let node_lowlink = lowlinks.get_mut(&node).unwrap();
+                *node_lowlink = (*node_lowlink).min(child_lowlink);
+            } else if on_stack.contains(child) {
+                let child_index = *indexes.get(child).unwrap();
+                let node_lowlink = lowlinks.get_mut(&node).unwrap();
+                *node_lowlink = (*node_lowlink).min(child_index);
+            }
+        }
+    }
+
+    if indexes.get(&node) == lowlinks.get(&node) {
+        let mut component = Vec::new();
+        while let Some(current) = stack.pop() {
+            on_stack.remove(&current);
+            component.push(current);
+            if current == node {
+                break;
+            }
+        }
+        components.push(component);
+    }
+}
+
+struct CallEdgeVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    caller: DefId,
+    edges: Vec<CallEdge>,
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for CallEdgeVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        if let ExprKind::Call(callee_expr, _) = expr.kind {
+            if let ExprKind::Path(ref qpath) = callee_expr.kind {
+                if let Some(def_id) = resolve_qpath_def_id(self.cx, qpath, callee_expr.hir_id) {
+                    self.edges.push(CallEdge {
+                        caller: self.caller,
+                        callee: def_id,
+                        span: expr.span,
+                    });
+                }
+            }
+        }
+
+        walk_expr(self, expr);
+    }
+}
+
+fn resolve_qpath_def_id(
+    cx: &LateContext<'_>,
+    qpath: &QPath<'_>,
+    hir_id: rustc_hir::HirId,
+) -> Option<DefId> {
+    cx.qpath_res(qpath, hir_id).opt_def_id()
+}

--- a/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/src/lib.rs
+++ b/nightly/2025-08-07/detectors/soroban/infinite-recursion-over-storage/src/lib.rs
@@ -177,29 +177,16 @@ fn compute_recursive_sccs(
     reachable: &HashSet<DefId>,
     graph: &HashMap<DefId, HashSet<DefId>>,
 ) -> Vec<Vec<DefId>> {
-    let mut index = 0usize;
-    let mut stack = Vec::new();
-    let mut on_stack = HashSet::new();
-    let mut indexes = HashMap::new();
-    let mut lowlinks = HashMap::new();
-    let mut components = Vec::new();
+    let mut tarjan = TarjanState::new(graph);
 
     for node in reachable {
-        if !indexes.contains_key(node) {
-            strong_connect(
-                *node,
-                graph,
-                &mut index,
-                &mut stack,
-                &mut on_stack,
-                &mut indexes,
-                &mut lowlinks,
-                &mut components,
-            );
+        if !tarjan.indexes.contains_key(node) {
+            tarjan.strong_connect(*node);
         }
     }
 
-    components
+    tarjan
+        .components
         .into_iter()
         .filter(|component| {
             if component.len() > 1 {
@@ -214,49 +201,87 @@ fn compute_recursive_sccs(
         .collect()
 }
 
-fn strong_connect(
-    node: DefId,
-    graph: &HashMap<DefId, HashSet<DefId>>,
-    index: &mut usize,
-    stack: &mut Vec<DefId>,
-    on_stack: &mut HashSet<DefId>,
-    indexes: &mut HashMap<DefId, usize>,
-    lowlinks: &mut HashMap<DefId, usize>,
-    components: &mut Vec<Vec<DefId>>,
-) {
-    indexes.insert(node, *index);
-    lowlinks.insert(node, *index);
-    *index += 1;
-    stack.push(node);
-    on_stack.insert(node);
+struct TarjanState<'a> {
+    graph: &'a HashMap<DefId, HashSet<DefId>>,
+    index: usize,
+    stack: Vec<DefId>,
+    on_stack: HashSet<DefId>,
+    indexes: HashMap<DefId, usize>,
+    lowlinks: HashMap<DefId, usize>,
+    components: Vec<Vec<DefId>>,
+}
 
-    if let Some(children) = graph.get(&node) {
-        for child in children {
-            if !indexes.contains_key(child) {
-                strong_connect(
-                    *child, graph, index, stack, on_stack, indexes, lowlinks, components,
-                );
-                let child_lowlink = *lowlinks.get(child).unwrap();
-                let node_lowlink = lowlinks.get_mut(&node).unwrap();
-                *node_lowlink = (*node_lowlink).min(child_lowlink);
-            } else if on_stack.contains(child) {
-                let child_index = *indexes.get(child).unwrap();
-                let node_lowlink = lowlinks.get_mut(&node).unwrap();
-                *node_lowlink = (*node_lowlink).min(child_index);
-            }
+impl<'a> TarjanState<'a> {
+    fn new(graph: &'a HashMap<DefId, HashSet<DefId>>) -> Self {
+        Self {
+            graph,
+            index: 0,
+            stack: Vec::new(),
+            on_stack: HashSet::new(),
+            indexes: HashMap::new(),
+            lowlinks: HashMap::new(),
+            components: Vec::new(),
         }
     }
 
-    if indexes.get(&node) == lowlinks.get(&node) {
-        let mut component = Vec::new();
-        while let Some(current) = stack.pop() {
-            on_stack.remove(&current);
-            component.push(current);
-            if current == node {
-                break;
+    fn strong_connect(&mut self, node: DefId) {
+        self.indexes.insert(node, self.index);
+        self.lowlinks.insert(node, self.index);
+        self.index += 1;
+        self.stack.push(node);
+        self.on_stack.insert(node);
+
+        if let Some(children) = self.graph.get(&node) {
+            for child in children {
+                if !self.indexes.contains_key(child) {
+                    self.strong_connect(*child);
+                    let child_lowlink = *self.lowlinks.get(child).unwrap();
+                    let node_lowlink = self.lowlinks.get_mut(&node).unwrap();
+                    *node_lowlink = (*node_lowlink).min(child_lowlink);
+                } else if self.on_stack.contains(child) {
+                    let child_index = *self.indexes.get(child).unwrap();
+                    let node_lowlink = self.lowlinks.get_mut(&node).unwrap();
+                    *node_lowlink = (*node_lowlink).min(child_index);
+                }
             }
         }
-        components.push(component);
+
+        if self.indexes.get(&node) == self.lowlinks.get(&node) {
+            let mut component = Vec::new();
+            while let Some(current) = self.stack.pop() {
+                self.on_stack.remove(&current);
+                component.push(current);
+                if current == node {
+                    break;
+                }
+            }
+            self.components.push(component);
+        }
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for CallEdgeVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        if let Some(def_id) = resolve_call_def_id(self.cx, expr) {
+            self.edges.push(CallEdge {
+                caller: self.caller,
+                callee: def_id,
+                span: expr.span,
+            });
+        }
+
+        walk_expr(self, expr);
+    }
+}
+
+fn resolve_call_def_id(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
+    match expr.kind {
+        ExprKind::Call(callee_expr, _) => match callee_expr.kind {
+            ExprKind::Path(ref qpath) => resolve_qpath_def_id(cx, qpath, callee_expr.hir_id),
+            _ => None,
+        },
+        ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
+        _ => None,
     }
 }
 
@@ -264,24 +289,6 @@ struct CallEdgeVisitor<'a, 'tcx> {
     cx: &'a LateContext<'tcx>,
     caller: DefId,
     edges: Vec<CallEdge>,
-}
-
-impl<'a, 'tcx> Visitor<'tcx> for CallEdgeVisitor<'a, 'tcx> {
-    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
-        if let ExprKind::Call(callee_expr, _) = expr.kind {
-            if let ExprKind::Path(ref qpath) = callee_expr.kind {
-                if let Some(def_id) = resolve_qpath_def_id(self.cx, qpath, callee_expr.hir_id) {
-                    self.edges.push(CallEdge {
-                        caller: self.caller,
-                        callee: def_id,
-                        span: expr.span,
-                    });
-                }
-            }
-        }
-
-        walk_expr(self, expr);
-    }
 }
 
 fn resolve_qpath_def_id(

--- a/test-cases/soroban/Cargo.lock
+++ b/test-cases/soroban/Cargo.lock
@@ -939,6 +939,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "infinite-recursion-over-storage-remediated-1"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-remediated-2"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-remediated-3"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-remediated-4"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-1"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-2"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-3"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-4"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-5"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-6"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-7"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "init-instead-of-constructor-remediated-1"
 version = "0.1.0"
 dependencies = [

--- a/test-cases/soroban/Cargo.lock
+++ b/test-cases/soroban/Cargo.lock
@@ -939,6 +939,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "infinite-recursion-over-storage-remediated-1"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-remediated-2"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-remediated-3"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-remediated-4"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-1"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-2"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-3"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-4"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-5"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-6"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "infinite-recursion-over-storage-vulnerable-7"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "insufficiently-random-values-remediated-1"
 version = "0.1.0"
 dependencies = [

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-1/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-1/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-remediated-1"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-1/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-1/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn write_once(env: Env, depth: u32) -> u32 {
+    env.storage().persistent().set(&COUNTER, &depth);
+    depth
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        write_once(env, depth)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-2/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-2/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-remediated-2"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-2/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-2/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+fn advance_once(depth: u32) -> u32 {
+    depth + 1
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(_env: Env, depth: u32) -> u32 {
+        advance_once(depth)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-3/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-3/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-remediated-3"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-3/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-3/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn unreachable_cycle_left(env: Env, depth: u32) -> u32 {
+    env.storage().instance().set(&COUNTER, &depth);
+    unreachable_cycle_right(env, depth + 1)
+}
+
+fn unreachable_cycle_right(env: Env, depth: u32) -> u32 {
+    unreachable_cycle_left(env, depth + 1)
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        let current: u32 = env.storage().temporary().get(&COUNTER).unwrap_or(depth);
+        current + 1
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-4/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-4/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-remediated-4"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-4/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/remediated/remediated-4/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn storage_helper(env: Env, depth: u32) -> u32 {
+    env.storage().persistent().set(&COUNTER, &depth);
+    depth
+}
+
+fn step_left(env: Env, depth: u32) -> u32 {
+    step_right(env, depth + 1)
+}
+
+fn step_right(env: Env, depth: u32) -> u32 {
+    let updated_depth = storage_helper(env, depth);
+    updated_depth + 1
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        step_left(env, depth)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-1/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-1/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-1"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-1/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-1/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn recurse(env: Env, depth: u32) -> u32 {
+        env.storage().persistent().set(&COUNTER, &depth);
+        Self::recurse(env, depth + 1)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-2/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-2/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-2"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-2/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-2/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn bounce_b(env: Env, depth: u32) -> u32 {
+    env.storage().instance().set(&COUNTER, &depth);
+    bounce_a(env, depth + 1)
+}
+
+fn bounce_a(env: Env, depth: u32) -> u32 {
+    bounce_b(env, depth + 1)
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        bounce_a(env, depth)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-3/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-3/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-3"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-3/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-3/src/lib.rs
@@ -1,0 +1,32 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn prepare(env: Env, depth: u32) -> u32 {
+    recurse_left(env, depth + 1)
+}
+
+fn recurse_left(env: Env, depth: u32) -> u32 {
+    recurse_middle(env, depth + 1)
+}
+
+fn recurse_middle(env: Env, depth: u32) -> u32 {
+    env.storage().temporary().set(&COUNTER, &depth);
+    recurse_right(env, depth + 1)
+}
+
+fn recurse_right(env: Env, depth: u32) -> u32 {
+    recurse_left(env, depth + 1)
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        prepare(env, depth)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-4/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-4/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-4"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-4/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-4/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn dispatch(env: Env, depth: u32, toggle: bool) -> u32 {
+    if toggle {
+        grow_storage(env, depth)
+    } else {
+        dispatch(env, depth + 1, true)
+    }
+}
+
+fn grow_storage(env: Env, depth: u32) -> u32 {
+    env.storage().persistent().set(&COUNTER, &depth);
+    dispatch(env, depth + 1, false)
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        dispatch(env, depth, false)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-5/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-5/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-5"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-5/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-5/src/lib.rs
@@ -1,0 +1,35 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        Self::enter(env, depth)
+    }
+
+    fn enter(env: Env, depth: u32) -> u32 {
+        if depth % 2 == 0 {
+            Self::touch_storage(env, depth)
+        } else {
+            Self::reenter(env, depth + 1)
+        }
+    }
+
+    fn touch_storage(env: Env, depth: u32) -> u32 {
+        env.storage()
+            .instance()
+            .get::<Symbol, u32>(&COUNTER)
+            .unwrap_or(depth);
+        Self::reenter(env, depth + 1)
+    }
+
+    fn reenter(env: Env, depth: u32) -> u32 {
+        Self::enter(env, depth + 1)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-6/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-6/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-6"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-6/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-6/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const COUNTER: Symbol = symbol_short!("COUNT");
+
+fn storage_helper(env: Env, depth: u32) -> u32 {
+    env.storage().persistent().set(&COUNTER, &depth);
+    depth
+}
+
+fn cycle_left(env: Env, depth: u32) -> u32 {
+    cycle_right(env, depth + 1)
+}
+
+fn cycle_right(env: Env, depth: u32) -> u32 {
+    let updated_depth = storage_helper(env.clone(), depth);
+    cycle_left(env, updated_depth + 1)
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(env: Env, depth: u32) -> u32 {
+        cycle_left(env, depth)
+    }
+}

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-7/Cargo.toml
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-7/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+edition = "2021"
+name = "infinite-recursion-over-storage-vulnerable-7"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-7/src/lib.rs
+++ b/test-cases/soroban/infinite-recursion-over-storage/vulnerable/vulnerable-7/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+fn recurse_without_storage(depth: u32) -> u32 {
+    recurse_without_storage(depth + 1)
+}
+
+#[contract]
+pub struct InfiniteRecursionOverStorage;
+
+#[contractimpl]
+impl InfiniteRecursionOverStorage {
+    pub fn start(_env: Env, depth: u32) -> u32 {
+        recurse_without_storage(depth)
+    }
+}


### PR DESCRIPTION
## Infinite recursion detector

### Description

- Category: `Denial of service`
- Severity: `Medium`

This detector looks for recursive call cycles reachable from a Soroban entrypoint. In Soroban, recursive execution can exhaust gas or overflow the call stack when the recursion has no effective terminal condition.

### Why is this bad?

Recursive cycles without an exit condition can keep calling themselves until execution runs out of gas or stack budget. That creates a denial-of-service pattern and can make otherwise simple entrypoints unexpectedly revert.

The detector is intentionally scoped to recursion reachable from Soroban entrypoints. It reports direct self-recursion and mutual-recursion cycles that can keep execution from terminating.

### PR contents
This PR has new detector code, tests and documentation.